### PR TITLE
Change 'VSTS' or 'Visual Studio Team Services' to 'Azure DevOps'

### DIFF
--- a/Extension/OVERVIEW.md
+++ b/Extension/OVERVIEW.md
@@ -1,6 +1,6 @@
 # DigitalOcean Tools
 
-DigitalOcean Tools provide the ability to upload and delete objects from DigitalOcean Spaces in Visual Studio Team Services Build and Release Management.
+DigitalOcean Tools provide the ability to upload and delete objects from DigitalOcean Spaces in Azure DevOps Build and Release Management.
 
 ![tasks-banner](images/tasks-banner.png)
 
@@ -35,7 +35,7 @@ Semantic Version Filter Options:
 
 ## Install the extension to your account
 
-You can find the latest stable version of the VSTS Extension tasks on the [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=marcelo-formentao.digitalocean-tools).
+You can find the latest stable version of the Azure DevOps Extension tasks on the [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=marcelo-formentao.digitalocean-tools).
 
 ## Known Issues
 

--- a/Extension/vss-extension.json
+++ b/Extension/vss-extension.json
@@ -9,7 +9,7 @@
       "id": "Microsoft.VisualStudio.Services"
     }
   ],
-  "description": "DigitalOcean Services Management with VSTS",
+  "description": "DigitalOcean Services Management with Azure DevOps",
   "categories": [
     "Build and release"
   ],

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ DigitalOcean Tools
 <br>
 </h1>
 
-<h4 align="center">Manage your DigitalOcean Services. For VSTS Builds and Releases.</h4>
+<h4 align="center">Manage your DigitalOcean Services. For Azure DevOps Builds and Releases.</h4>
 
-<p align="center">DigitalOcean Tools provide the ability to upload and delete objects from DigitalOcean Spaces in Visual Studio Team Services Build and Release Management. <a href="https://github.com/marceloavf/digitalocean-tools-vsts/wiki">Learn More</a></p>
+<p align="center">DigitalOcean Tools provide the ability to upload and delete objects from DigitalOcean Spaces in Azure DevOps Build and Release Management. <a href="https://github.com/marceloavf/digitalocean-tools-vsts/wiki">Learn More</a></p>
 
 <h4 align="center">
 
@@ -25,7 +25,7 @@ DigitalOcean Tools
 
 ## 📟 &nbsp; Install the extension to your account
 
-You can find the latest stable version of the VSTS Extension tasks on the [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=marcelo-formentao.digitalocean-tools).
+You can find the latest stable version of the Azure DevOps Extension tasks on the [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=marcelo-formentao.digitalocean-tools).
 
 ## 🤝 &nbsp; Contribute
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "digitalocean-tools-vsts",
   "version": "0.1.1",
-  "description": "DigitalOcean task for the Visual Studio Team Services system",
+  "description": "DigitalOcean task for the Azure DevOps system",
   "author": "Marcelo Formentão <marceloavf3@hotmail.com>",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
### Description

A quick and easy issue to resolve in light of the new branding change by Microsoft. Ran a `grep` command to find out the list of files affected: `grep -rlE "(VSTS|Visual Studio Team Services)" * > ~/files.txt`

And then iterated all of them and replaced offending lines: `for file in $(cat ~/files.txt); do sed -i 's/VSTS\|Visual Studio Team Services/Azure DevOps/g' "$file"; done`

### Review

- [x] Check if everything is okay and nothing was overdone
