### PR TITLE
fix: update node version in task to 16

### DIFF
--- a/Tasks/DigitalOceanDoctlInstaller/task.json
+++ b/Tasks/DigitalOceanDoctlInstaller/task.json
@@ -23,7 +23,7 @@
   "satisfies": ["doctl"],
   "minimumAgentVersion": "1.91.0",
   "execution": {
-    "Node10": {
+    "Node16": {
       "target": "index.js",
       "argumentFormat": ""
     }


### PR DESCRIPTION
### Description

Update node version in task file of DigitalOceanDoctlInstaller to avoid warning showed by Azure Devops
